### PR TITLE
Take flashes only from reserved keys (error, warning, notice) or `flash` key

### DIFF
--- a/flame-flash.gemspec
+++ b/flame-flash.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |s|
 	s.license     = 'MIT'
 
 	s.add_runtime_dependency 'flame', '>= 5.0.0.rc3', '< 6'
+	s.add_runtime_dependency 'gorilla-patch', '>= 1', '< 3'
 
 	s.add_development_dependency 'pry-byebug', '~> 3.6'
 	s.add_development_dependency 'rack-test', '~> 0.8'

--- a/lib/flame/flash.rb
+++ b/lib/flame/flash.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'gorilla-patch/slice'
+
 require_relative 'flash/flash_array'
 
 module Flame
@@ -16,12 +18,7 @@ module Flame
 		##   redirect ArticlesController, :show, id: 2, error: 'Access required'
 		def redirect(*args)
 			if args.last.is_a? Hash
-				if args[0].is_a? String
-					flashes = args.pop
-				else
-					args[-1], flashes = extract_flashes(args)
-				end
-				flash.merge(flashes)
+				flash.merge args.first.is_a?(String) ? args.pop : extract_flashes(args)
 			end
 			flash.next.concat(flash.now) ## for multiple redirects
 			super
@@ -44,13 +41,19 @@ module Flame
 			).scope(key)
 		end
 
+		RESERVED_FLASH_KEYS = %i[error warning notice].freeze
+
+		using GorillaPatch::Slice
+
 		## Split Hash-argument to parameters and flashes
 		def extract_flashes(args)
 			add_controller_class(args)
-			parameters = args[0].instance_method(args[1]).parameters.map(&:last)
-			args.last.partition do |key, _value|
-				parameters.include?(key) || key == :params
-			end.map(&:to_h)
+			flashes = args.last.delete(:flash) { {} }
+			## Yeah, `RESERVED_FLASH_KEYS` will rest in `args`
+			## and will be passed into parent's `redirect`.
+			## But I don't see a problem cause of it for now.
+			## If you see - please, send a PR, or create an issue.
+			flashes.merge args.last.slice(*RESERVED_FLASH_KEYS)
 		end
 
 		## Move flash.next to session

--- a/spec/readme_spec.rb
+++ b/spec/readme_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+describe 'README' do
+	subject { File.read File.join(__dir__, '..', 'README.md') }
+
+	it 'includes reserved flash keys' do
+		expect(subject).to include(
+			*Flame::Flash::RESERVED_FLASH_KEYS.map { |key| "*   `#{key}`" }
+		)
+	end
+end


### PR DESCRIPTION
Don't extract parameters for controller's path as flashes.

Reference: http://guides.rubyonrails.org/action_controller_overview.html#the-flash