### PR TITLE
Don't exclude specs from coverage

### DIFF
--- a/spec/flame/flash_spec.rb
+++ b/spec/flame/flash_spec.rb
@@ -13,8 +13,8 @@ describe Flame::Flash do
 			private
 
 			def server_error(exception)
-				p exception
-				puts exception.backtrace
+				# p exception
+				# puts exception.backtrace
 			end
 		end
 	end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
 require 'simplecov'
-SimpleCov.start do
-	add_filter '/spec/'
-end
 SimpleCov.start
 
 if ENV['CODECOV_TOKEN']


### PR DESCRIPTION
If we'll have unused code in specs — we should know about it.